### PR TITLE
adding a stop in a couple places

### DIFF
--- a/src/states/ArmingState.java
+++ b/src/states/ArmingState.java
@@ -84,6 +84,7 @@ public class ArmingState extends SecuritySystemState implements Notifiable {
 	 */
 	@Override
 	public void leave() {
+		timer.stop();
 		timer = null;
 		SecuritySystemContext.instance().showTimeLeft(0, "Armed");
 		SecuritySystemContext.instance().showAway();

--- a/src/states/TriggeredState.java
+++ b/src/states/TriggeredState.java
@@ -94,6 +94,7 @@ public class TriggeredState extends SecuritySystemState implements Notifiable {
 	 */
 	@Override
 	public void leave() {
+		timer.stop();
 		timer = null;
 		SecuritySystemContext.instance().showTimeLeft(0, "Breach");
 	}


### PR DESCRIPTION
Probably redundant, but might be best to use stop() method of TimeTracker to stop the Timer instance from observing Timekeeper